### PR TITLE
Fixed 404 page styling

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,21 +2,7 @@
 layout: default
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
-
-<div class="container">
+<div class="container col align-center">
   <h1>404</h1>
 
   <p><strong>Page not found :(</strong></p>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="col">
+<footer class="col mt-auto">
   <section class="container col flex-center" aria-label="My Personal Details">
     <div class="logo" aria-label="Text logo">
       <span class="first">Riaz</span><span class="second">Shageer</span>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/assets/css/styles.css">
 </head>
 
-<body>
+<body class="col">
   {{content}}
 
   {% include footer.html %}

--- a/_sass/_mixins.scss
+++ b/_sass/_mixins.scss
@@ -10,6 +10,9 @@
       #{$prop-name}:var(#{$var-name + "-" + ($inc * 100)});
     }
   }
+  .#{$class-name + "-auto"}{
+    #{$prop-name}:auto;
+  }
 }
 
 @mixin fluidify($screen_min, $screen_max, $min_sz, $max_sz, $prop){


### PR DESCRIPTION
The styling on the 404 page included a footer that would not stick to
the bottom on shorter pages as well as some inline styling that came
standard to jekyll.

This was fixed to fit the styling of the site